### PR TITLE
I've made a single socket bidirectional

### DIFF
--- a/example/echo.dart
+++ b/example/echo.dart
@@ -12,7 +12,9 @@ void main(List<String> args) {
 
   print(greenPen('echo osc listening on port $port... (^C to quit)'));
 
-  final socket = OSCSocket(port: port);
-  socket.listen(
-      (msg) => print("${grayPen('received:')} ${bluePen(msg.toString())}"));
+  final socket = OSCSocket(serverPort: port);
+  socket.listen((msg) {
+    print("${grayPen('received:')} ${bluePen(msg.toString())}");
+    socket.reply(OSCMessage('/received', arguments: []));
+  });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: osc
 description: A simple Open Sound Control (OSC) protocol implementation for Dart.
-version: 0.0.1
+version: 0.0.2
 
 environment:
   sdk: '>=2.2.2 <3.0.0'


### PR DESCRIPTION
The previous version of OSCSocket was incorrectly attempting to bind to a remote ip address and port instead of only local addresses and ports. Additionally, there was no way to have a single socket be able to send and listen. That is fixed now.