### PR TITLE
fixed stringcodec length

### DIFF
--- a/lib/src/convert.dart
+++ b/lib/src/convert.dart
@@ -185,7 +185,7 @@ class StringCodec extends DataCodec<String> {
   Converter<String, List<int>> get encoder => const StringEncoder();
 
   @override
-  int length(String value) => value.length;
+  int length(String value) =>  value.length % 4 == 0 ? value.length + 1 : value.length;
 
   @override
   String toValue(String string) => string;


### PR DESCRIPTION
when the first string length is a multiple of 4, the following arguments do not work